### PR TITLE
Fix broken app and test suite so CI tests actually run

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,11 +13,14 @@ jobs:
       uses: actions/setup-python@v6
       with:
         python-version: 3.12
+    - name: Install system dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y python3-tk xvfb
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt
     - name: Run tests
       run: |
-        python -m unittest discover tests
-        python -m unittest discover craftclash/tests
+        xvfb-run -a python -m pytest tests/

--- a/main.py
+++ b/main.py
@@ -20,30 +20,39 @@ Copyright (C) 2017-2026 willtheorangeguy
 # Main program window.
 
 # Import Statements
+import os
 from tkinter import Tk, Label, Button, PhotoImage, RAISED
 from craftclash.optionscreen import optionsscreen
 from craftclash.aboutscreen import aboutscreen
 
+# Resolve assets relative to this file so the app works regardless of the
+# current working directory.
+ASSETS_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "assets")
+
 
 def craftclash():
-    """Main program window."""
+    """Build and return the main program window.
+
+    The window is returned without starting the Tk event loop so that it can
+    be created and inspected by tests. Call ``mainloop()`` on the returned
+    window (see ``__main__`` below) to actually run the game.
+    """
     # Window Elements
     window = Tk()
     window.title("CraftClash - Windows - 0.0.4 BETA")
     window.configure(bg="sky blue")
 
     # Images
-    titleimg = PhotoImage(file="assets/logo/titlelogo.gif")
-    playimg = PhotoImage(file="assets/gui/play-circle.gif")
-    optionimg = PhotoImage(file="assets/gui/cog.gif")
-    aboutimg = PhotoImage(file="assets/gui/about.gif")
+    titleimg = PhotoImage(file=os.path.join(ASSETS_DIR, "logo", "titlelogo.gif"))
 
     # Widgets
     title_label = Label(window, image=titleimg)
+    # Keep a reference to the image so it is not garbage collected once this
+    # function returns (Tk does not hold a Python reference of its own).
+    title_label.image = titleimg
     btn_play = Button(
         window, text="Play!", height=3, width=60, bd=4, relief=RAISED, command=exit
     )
-    play_img = Label(window, image=playimg)
     btn_options = Button(
         window,
         text="Options",
@@ -53,7 +62,6 @@ def craftclash():
         relief=RAISED,
         command=optionsscreen,
     )
-    options_img = Label(window, image=optionimg)
     btn_about = Button(
         window,
         text="About",
@@ -63,7 +71,6 @@ def craftclash():
         relief=RAISED,
         command=aboutscreen,
     )
-    about_img = Label(window, image=aboutimg)
     copyright_label = Label(
         window,
         text="Copyright © 2017 - 2026 willtheorangeguy. \t\t\t Version 0.0.4 BETA",
@@ -71,18 +78,13 @@ def craftclash():
 
     # Pack Statements
     title_label.grid(row=1, column=2, rowspan=2, pady=10)
-    play_img.grid(row=3, column=1)
     btn_play.grid(row=3, column=2, columnspan=2)
-    options_img.grid(row=4, column=1)
     btn_options.grid(row=4, column=2, columnspan=2)
-    about_img.grid(row=5, column=1)
     btn_about.grid(row=5, column=2, columnspan=2)
     copyright_label.grid(row=6, column=1, columnspan=5)
 
-    # Sustain Window
-    window.mainloop()
     return window
 
 
 if __name__ == "__main__":
-    craftclash()
+    craftclash().mainloop()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -21,11 +21,16 @@ class TestApp(unittest.TestCase):
 
     def tearDown(self):
         """Destroy the application."""
-        self.app.window.destroy()
+        # ``craftclash()`` returns the Tk window itself, so destroy it directly.
+        self.app.destroy()
 
     def test_window_exists(self):
         """Test if the window exists."""
         self.assertIsNotNone(self.app)
+
+    def test_window_title(self):
+        """Test the window title."""
+        self.assertEqual(self.app.title(), "CraftClash - Windows - 0.0.4 BETA")
 
     def test_window_background(self):
         """Test the window background color."""
@@ -58,6 +63,12 @@ class TestApp(unittest.TestCase):
         """Test if the copyright label exists."""
         copyright_label = self.app.grid_slaves(row=6, column=1)[0]
         self.assertIsInstance(copyright_label, Label)
+
+    def test_buttons_have_commands(self):
+        """Test that every button is wired to a command callback."""
+        for row in (3, 4, 5):
+            button = self.app.grid_slaves(row=row, column=2)[0]
+            self.assertNotEqual(button.cget("command"), "")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
**Describe the Pull Request**

The "Pytest" workflow exists but the tests never actually passed. Several problems compounded:

- `main.py` crashed on launch loading non-existent icon assets (`assets/gui/play-circle.gif`, `cog.gif`, `about.gif` — that directory does not exist in the repo), so every test failed in `setUp`.
- `craftclash()` called `window.mainloop()` *before* returning the window, so it blocked forever and the tests could never get the window back.
- The tests' `tearDown` called `self.app.window.destroy()`, but `craftclash()` returns the `Tk` window itself, which has no `.window` attribute.
- The workflow ran `python -m unittest discover craftclash/tests`, but that directory does not exist, and it provided no virtual display for Tkinter (Tk cannot open a display on headless CI runners).

Changes:

- **`main.py`** — remove the three decorative icon `Label`s that pointed at missing `assets/gui/*.gif` files (the title logo, which does exist, is kept); resolve the assets path relative to the file so it works from any working directory; keep a reference to the logo image so it survives garbage collection; and return the window *without* starting the event loop so it is testable. `mainloop()` now runs from `__main__`.
- **`tests/test_main.py`** — fix `tearDown` to destroy the window directly, and add coverage for the window title and that each button is wired to a command.
- **`.github/workflows/tests.yml`** — install `python3-tk` + `xvfb`, run the suite with `pytest` under a virtual display (`xvfb-run`), and stop discovering the non-existent `craftclash/tests` directory.

**Expected Behavior**

`python main.py` launches the window without crashing, and the test workflow runs the suite headlessly and passes.

**Fixes the Following Issues**

The test workflow that previously could never pass now runs 9 passing tests.

**Screenshots**

N/A

**Desktop Developed On (please complete the following information):**

- OS: Ubuntu (CI runner, ubuntu-latest)
- Program Version: 0.0.4 BETA
- Python Version: 3.12

**Additional Context**

Verified locally under `xvfb-run`: all 9 tests pass via both `pytest tests/` and `unittest discover tests`, the app builds and renders headlessly, and `pylint` rates `main.py` and the tests 10.00/10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PTH1Dd2qzQJdL6pxD6p32v

---
_Generated by [Claude Code](https://claude.ai/code/session_01PTH1Dd2qzQJdL6pxD6p32v)_