### PR TITLE
Use pytest-xvfb to fix headless Tkinter display errors in CI tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,4 +23,4 @@ jobs:
         pip install -r requirements.txt
     - name: Run tests
       run: |
-        xvfb-run -a python -m pytest tests/
+        python -m pytest tests/

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ PyInstaller>=6.21.0
 Pillow>=12.3.0
 cx-Freeze>=8.6.4
 pytest
+pytest-xvfb


### PR DESCRIPTION
## Summary

- Add `pytest-xvfb` to `requirements.txt` so pytest automatically starts a virtual framebuffer before test collection
- Remove the `xvfb-run` wrapper from `tests.yml` — `pytest-xvfb` handles display setup more reliably by hooking into pytest startup and waiting for Xvfb to be ready, eliminating the timing-related `_tkinter.TclError: no display name and no $DISPLAY environment variable` failures

## Root cause

The previous approach used `xvfb-run -a python -m pytest tests/` to wrap the test runner with a virtual display. This is prone to timing races where `Tk()` is called before Xvfb has finished initializing. `pytest-xvfb` hooks directly into pytest's session start, starts Xvfb, sets `$DISPLAY`, and only then allows collection and test execution.

The `xvfb` system package (already installed via apt in the workflow) is still required as the backend for `pytest-xvfb`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SCR51zzLWX1HudmNSj9ASm)_